### PR TITLE
quell lots of GCC warnings

### DIFF
--- a/Library/StdDriver/src/adc.c
+++ b/Library/StdDriver/src/adc.c
@@ -44,6 +44,7 @@ void ADC_Open(ADC_T *adc,
               uint32_t u32OpMode,
               uint32_t u32ChMask)
 {
+    (void) adc;
 
     ADC->ADCR = (ADC->ADCR & (~(ADC_ADCR_DIFFEN_Msk | ADC_ADCR_ADMD_Msk))) | \
                 (u32InputMode) | \
@@ -61,6 +62,7 @@ void ADC_Open(ADC_T *adc,
   */
 void ADC_Close(ADC_T *adc)
 {
+    (void) adc;
     SYS->IPRST1 |= SYS_IPRST1_ADCRST_Msk;
     SYS->IPRST1 &= ~SYS_IPRST1_ADCRST_Msk;
     return;
@@ -90,6 +92,8 @@ void ADC_EnableHWTrigger(ADC_T *adc,
                          uint32_t u32Source,
                          uint32_t u32Param)
 {
+    (void) adc;
+
     if(u32Source == ADC_ADCR_TRGS_STADC)
     {
         ADC->ADCR = (ADC->ADCR & ~(ADC_ADCR_TRGS_Msk | ADC_ADCR_TRGCOND_Msk | ADC_ADCR_TRGEN_Msk)) | (u32Source) | (u32Param) | ADC_ADCR_TRGEN_Msk;
@@ -113,6 +117,7 @@ void ADC_EnableHWTrigger(ADC_T *adc,
   */
 void ADC_DisableHWTrigger(ADC_T *adc)
 {
+    (void) adc;
     ADC->ADCR &= ~(ADC_ADCR_TRGS_Msk | ADC_ADCR_TRGCOND_Msk | ADC_ADCR_TRGEN_Msk);
     return;
 }
@@ -130,6 +135,8 @@ void ADC_DisableHWTrigger(ADC_T *adc)
   */
 void ADC_EnableInt(ADC_T *adc, uint32_t u32Mask)
 {
+    (void) adc;
+
     if((u32Mask) & ADC_ADF_INT)
         ADC->ADCR |= ADC_ADCR_ADIE_Msk;
     if((u32Mask) & ADC_CMP0_INT)
@@ -153,6 +160,8 @@ void ADC_EnableInt(ADC_T *adc, uint32_t u32Mask)
   */
 void ADC_DisableInt(ADC_T *adc, uint32_t u32Mask)
 {
+    (void) adc;
+
     if((u32Mask) & ADC_ADF_INT)
         ADC->ADCR &= ~ADC_ADCR_ADIE_Msk;
     if((u32Mask) & ADC_CMP0_INT)

--- a/Library/StdDriver/src/fmc.c
+++ b/Library/StdDriver/src/fmc.c
@@ -228,7 +228,7 @@ uint32_t FMC_ReadDataFlashBaseAddr(void)
   */
 int32_t FMC_ReadConfig(uint32_t *u32Config, uint32_t u32Count)
 {
-    int32_t i;
+    uint32_t i;
 
     for(i = 0; i < u32Count; i++)
         u32Config[i] = FMC_Read(FMC_CONFIG_BASE + i * 4);
@@ -253,7 +253,7 @@ int32_t FMC_ReadConfig(uint32_t *u32Config, uint32_t u32Count)
   */
 int32_t FMC_WriteConfig(uint32_t *u32Config, uint32_t u32Count)
 {
-    int32_t i;
+    uint32_t i;
 
     for(i = 0; i < u32Count; i++)
     {

--- a/Library/StdDriver/src/pwm.c
+++ b/Library/StdDriver/src/pwm.c
@@ -41,6 +41,8 @@ uint32_t PWM_ConfigCaptureChannel(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u
     uint32_t u32NearestUnitTimeNsec;
     uint32_t u32Prescale = 1, u32CNR = 0xFFFF;
 
+    (void) u32CaptureEdge;
+
     if(pwm == PWM0)
         u32Src = CLK->CLKSEL1 & CLK_CLKSEL1_PWM0SEL_Msk;
     else//(pwm == PWM1)
@@ -285,6 +287,7 @@ void PWM_DisableADCTrigger(PWM_T *pwm, uint32_t u32ChannelNum)
  */
 void PWM_ClearADCTriggerFlag(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32Condition)
 {
+    (void) u32Condition;
     (pwm)->STATUS = (PWM_STATUS_ADCTRGF0_Msk << u32ChannelNum);
 }
 
@@ -726,6 +729,7 @@ uint32_t PWM_GetFaultBrakeIntFlag(PWM_T *pwm, uint32_t u32BrakeSource)
  */
 void PWM_EnablePeriodInt(PWM_T *pwm, uint32_t u32ChannelNum,  uint32_t u32IntPeriodType)
 {
+    (void) u32IntPeriodType;
     (pwm)->INTEN0 |= (PWM_INTEN0_PIEN0_Msk << u32ChannelNum);
 }
 
@@ -1157,7 +1161,7 @@ void PWM_DisableSyncPinInverse(PWM_T *pwm)
  */
 void PWM_SetClockSource(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32ClkSrcSel)
 {
-    (pwm)->CLKSRC = (pwm)->CLKSRC & ~(PWM_CLKSRC_ECLKSRC0_Msk << ((u32ChannelNum >> 1) << 3)) | \
+    (pwm)->CLKSRC = ((pwm)->CLKSRC & ~(PWM_CLKSRC_ECLKSRC0_Msk << ((u32ChannelNum >> 1) << 3))) | \
                     (u32ClkSrcSel << ((u32ChannelNum >> 1) << 3));
 }
 

--- a/Library/StdDriver/src/retarget.c
+++ b/Library/StdDriver/src/retarget.c
@@ -44,14 +44,14 @@ enum { r0, r1, r2, r3, r12, lr, pc, psr};
  */
 static void stackDump(uint32_t stack[])
 {
-    printf("r0  = 0x%x\n", stack[r0]);
-    printf("r1  = 0x%x\n", stack[r1]);
-    printf("r2  = 0x%x\n", stack[r2]);
-    printf("r3  = 0x%x\n", stack[r3]);
-    printf("r12 = 0x%x\n", stack[r12]);
-    printf("lr  = 0x%x\n", stack[lr]);
-    printf("pc  = 0x%x\n", stack[pc]);
-    printf("psr = 0x%x\n", stack[psr]);
+    printf("r0  = 0x%lx\n", stack[r0]);
+    printf("r1  = 0x%lx\n", stack[r1]);
+    printf("r2  = 0x%lx\n", stack[r2]);
+    printf("r3  = 0x%lx\n", stack[r3]);
+    printf("r12 = 0x%lx\n", stack[r12]);
+    printf("lr  = 0x%lx\n", stack[lr]);
+    printf("pc  = 0x%lx\n", stack[pc]);
+    printf("psr = 0x%lx\n", stack[psr]);
 }
 
 /**
@@ -649,6 +649,7 @@ void _ttywrch(int ch)
 
 int fputc(int ch, FILE *stream)
 {
+    (void) stream;
     SendChar(ch);
     return ch;
 }
@@ -659,6 +660,8 @@ int fputc(int ch, FILE *stream)
 int _write (int fd, char *ptr, int len)
 {
     int i = len;
+
+    (void) fd;
 
     while(i--) {
         while(DEBUG_PORT->FIFOSTS & UART_FIFOSTS_TXFULL_Msk);
@@ -675,6 +678,8 @@ int _write (int fd, char *ptr, int len)
 
 int _read (int fd, char *ptr, int len)
 {
+    (void) fd;
+    (void) len;
 
     while((DEBUG_PORT->FIFOSTS & UART_FIFOSTS_RXEMPTY_Msk) != 0);
     *ptr = DEBUG_PORT->DAT;

--- a/Library/StdDriver/src/timer.c
+++ b/Library/StdDriver/src/timer.c
@@ -273,6 +273,9 @@ void TIMER_EnableFreqCounter(TIMER_T *timer, uint32_t u32DropCount, uint32_t u32
 {
     TIMER_T *t;    // store the timer base to configure compare value
 
+    (void)u32DropCount;
+    (void)u32Timeout;
+
     t = (timer == TIMER0) ? TIMER1 : TIMER3;
 
     t->CMP = 0xFFFFFF;

--- a/Library/StdDriver/src/usbd.c
+++ b/Library/StdDriver/src/usbd.c
@@ -435,7 +435,7 @@ void USBD_StandardRequest(void)
             {
                 if(g_usbd_SetupPacket[2] == FEATURE_ENDPOINT_HALT)
                 {
-                    int32_t epNum, i;
+                    uint32_t epNum, i;
 
                     /* EP number stall is not allow to be clear in MSC class "Error Recovery Test".
                        a flag: g_u32EpStallLock is added to support it */

--- a/Library/StdDriver/src/usci_spi.c
+++ b/Library/StdDriver/src/usci_spi.c
@@ -47,7 +47,7 @@ uint32_t USPI_Open(USPI_T *uspi, uint32_t u32MasterSlave, uint32_t u32SPIMode,  
     uint32_t u32ClkDiv = 0;
     uint32_t u32Pclk;
 
-    if(uspi == USPI0 | uspi == USPI2)
+    if((uspi == USPI0) || (uspi == USPI2))
     {
         u32Pclk = CLK_GetPCLK0Freq();
     }
@@ -144,6 +144,7 @@ void USPI_DisableAutoSS(USPI_T *uspi)
   */
 void USPI_EnableAutoSS(USPI_T *uspi, uint32_t u32SSPinMask, uint32_t u32ActiveLevel)
 {
+    (void) u32SSPinMask;
     uspi->LINECTL = (uspi->LINECTL & ~USPI_LINECTL_CTLOINV_Msk) | u32ActiveLevel;
     uspi->PROTCTL |= USPI_PROTCTL_AUTOSS_Msk;
 }
@@ -159,7 +160,7 @@ uint32_t USPI_SetBusClock(USPI_T *uspi, uint32_t u32BusClock)
     uint32_t u32ClkDiv;
     uint32_t u32Pclk;
 
-    if(uspi == USPI0 | uspi == USPI2)
+    if((uspi == USPI0) || (uspi == USPI2))
     {
         u32Pclk = CLK_GetPCLK0Freq();
     }
@@ -188,7 +189,7 @@ uint32_t USPI_GetBusClock(USPI_T *uspi)
 
     u32ClkDiv = (uspi->BRGEN & USPI_BRGEN_CLKDIV_Msk) >> USPI_BRGEN_CLKDIV_Pos;
 
-    if(uspi == USPI0 | uspi == USPI2)
+    if((uspi == USPI0) || (uspi == USPI2))
     {
         return (CLK_GetPCLK0Freq() / ((u32ClkDiv + 1) << 1));
     }


### PR DESCRIPTION
Without such changes, the code will not be compiled by modern versions of gcc that have been configured to treat warnings as errors.
