### PR TITLE
usci_i2c.c: bug in UI2C_WriteByte() for UI2C_PROTSTS_STORIF

### DIFF
--- a/Library/StdDriver/src/usci_i2c.c
+++ b/Library/StdDriver/src/usci_i2c.c
@@ -568,7 +568,7 @@ uint8_t UI2C_WriteByte(UI2C_T *ui2c, uint8_t u8SlaveAddr, const uint8_t data)
             u8Ctrl = UI2C_CTL_PTRG | UI2C_CTL_STO;            
             u8Err = 1;
         }
-        else if((ui2c->PROTSTS & UI2C_PROTSTS_NACKIF_Msk) == UI2C_PROTSTS_STORIF_Msk)
+        else if((ui2c->PROTSTS & UI2C_PROTSTS_STORIF_Msk) == UI2C_PROTSTS_STORIF_Msk)
         {
             UI2C_CLR_PROT_INT_FLAG(ui2c, UI2C_PROTSTS_STORIF_Msk);                  /* Clear STOP INT Flag */ 
             u8Xfering = 0;


### PR DESCRIPTION
It looks like the author copied and pasted the UI2C_PROTSTS_NACKIF_Msk code immediately above, but then forgot to change the mask to UI2C_PROTSTS_STORIF_Msk.
I didn't catch this, but the owner of the TinyUSB did thanks to the one of the latest GCC error-checking features.